### PR TITLE
Missed quotes for conftest.SYNCPACK variable

### DIFF
--- a/pf_{{cookiecutter.syncpack_name}}/tests/conftest.py
+++ b/pf_{{cookiecutter.syncpack_name}}/tests/conftest.py
@@ -1,1 +1,1 @@
-SYNCPACK = {{cookiecutter.syncpack_name}}
+SYNCPACK = "{{cookiecutter.syncpack_name}}"


### PR DESCRIPTION
`conftest.SYNCPACK` must be a string