### PR TITLE
Add dev_container_version property to use a specific image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You will be asked about basic information:
 | version | Initial SyncPack Version |
 | requires_minimum_pf_version | Which version(s) of PowerFlow will this SyncPack support? |
 | dev_container_source | Use SL External if you are not a ScienceLogic employee |
-
+| dev_container_version | dev_container_version image version. i.e. for PF 2.4.1, the version should be 2.4.1 |
 
 Visual Studio Code
 ================================

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,5 +6,6 @@
 	"syncpack_description": "PF Syncpack for testing",
 	"version": "0.0.1",
 	"requires_minimum_pf_version": ">=2.0.0",
-	"dev_container_source": ["SL Internal", "SL External"]
+	"dev_container_source": ["SL Internal", "SL External"],
+	"dev_container_version":  "latest"
 }

--- a/pf_{{cookiecutter.syncpack_name}}/.devcontainer/devcontainer.json
+++ b/pf_{{cookiecutter.syncpack_name}}/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/python-3
 {
 	"name": "{{cookiecutter.syncpack_name}}",
-	"image": "{{ 'sciencelogic' if cookiecutter.dev_container_source == 'SL External' else 'scr.sl1.io' }}/pf-syncpack-devcontainer:latest",
+	"image": "{{ 'registry.scilo.tools/sciencelogic' if cookiecutter.dev_container_source == 'SL External' else 'registry.scilo.tools/internal' }}/pf-syncpack-devcontainer:{{cookiecutter.dev_container_version}}",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
@@ -33,5 +33,5 @@
 	"postCreateCommand": "pip3 install -e .",
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	 "remoteUser": "python"
 }

--- a/pf_{{cookiecutter.syncpack_name}}/{{cookiecutter.syncpack_name}}/apps/dummy_app.json
+++ b/pf_{{cookiecutter.syncpack_name}}/{{cookiecutter.syncpack_name}}/apps/dummy_app.json
@@ -7,7 +7,8 @@
   "steps": [
     {
       "name": "ds1",
-      "file": "DummyStep"
+      "file": "DummyStep",
+      "syncpack": "{{cookiecutter.syncpack_name}}"
     }
   ]
 }


### PR DESCRIPTION
 - add dev_container_version property and update readme
 - add syncpack property so the test_app_files can pass
 - update the dev_container registry
 - update the user to be `python` as otherwise vscode is not able to install the syncpack successfully
