### PR TITLE
set default shell for devcontainer and add steps to install offline deps

### DIFF
--- a/pf_{{cookiecutter.syncpack_name}}/.devcontainer/devcontainer.json
+++ b/pf_{{cookiecutter.syncpack_name}}/.devcontainer/devcontainer.json
@@ -5,20 +5,30 @@
 	"image": "{{ 'registry.scilo.tools/sciencelogic' if cookiecutter.dev_container_source == 'SL External' else 'registry.scilo.tools/internal' }}/pf-syncpack-devcontainer:{{cookiecutter.dev_container_version}}",
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"python.pythonPath": "/usr/local/bin/python",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
-	},
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "python.pythonPath": "/usr/local/bin/python",
+                "python.linting.enabled": true,
+                "python.linting.pylintEnabled": true,
+                "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+                "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+                "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+                "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+                "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+                "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+                "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+                "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+                "terminal.integrated.defaultProfile.linux": "bash"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ]
+        }
+    },
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [

--- a/pf_{{cookiecutter.syncpack_name}}/.offline_dependencies/README.txt
+++ b/pf_{{cookiecutter.syncpack_name}}/.offline_dependencies/README.txt
@@ -1,1 +1,5 @@
-Copy all the needed wheels(including SL Syncpacks) files into this .offline_dependencies directory
+# Install offline dependencies into the devcontainer
+
+1. Copy all the needed wheels(including SL Syncpacks) files into this .offline_dependencies directory
+2. Add the corresponding dependencies a syncpack needs to the 'requires_dist' property in the meta.json file
+3. Once the devcontainer is up and running, run one of the vscode tasks to install a syncpack using offline dependencies. i.e. 'PF: Install SP - Offline Dependencies'


### PR DESCRIPTION

 - update devcontainer default custom settings to stop deprecation warnings
 - set devcontainer default shell
 - add steps to install offline dependencies to readme file